### PR TITLE
GitHub Actions workflow for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+---
+# This workflow action builds and then publishes the collection
+# to Ansible Galaxy.
+name: Release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  release:
+    uses:
+      redhat-cop/ansible_collections_tooling/.github/workflows/release.yml@main
+    with:
+      collection_namespace: infra
+      collection_name: quay_configuration
+      collection_version: ${{ github.ref_name }}
+      collection_repo: https://github.com/redhat-cop/quay_configuration
+    secrets:
+      # Ansible Galaxy key that is used to publish the collection
+      api_key: ${{ secrets.GALAXY_INFRA_KEY }}
+      # GitHub token used to copy the collection tar to the GitHub release
+      token: ${{ secrets.GITHUB_TOKEN }}
+...


### PR DESCRIPTION
Fixes #3 by adding the `release.yml` GitHub action workflow, which is triggered when a new release is published in GitHub.
This workflow uses the `redhat-cop/ansible_collections_tooling/.github/workflows/release.yml` COP workflow.

The workflow requires an Ansible Galaxy API key to declare in the repository settings, which is not set (and therefore the workflow does not work)
Someone with permissions to the `infra` namespace in Ansible Galaxy can create such a key.

Also, the Sphinx documentation for the collection is removed from the repository, and therefore the version issue is resolved.